### PR TITLE
Update Install-CCMClient.ps1

### DIFF
--- a/Autopilot/ConfigMgr Client/Install-CCMClient.ps1
+++ b/Autopilot/ConfigMgr Client/Install-CCMClient.ps1
@@ -66,4 +66,4 @@ $T = New-ScheduledTaskTrigger -Daily -At ([System.DateTime]::Now).AddMinutes($Mi
 $P = New-ScheduledTaskPrincipal "NT Authority\System"
 $S = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
 $task = New-ScheduledTask -Action $A -Trigger $T -Principal $P -Settings $S
-Register-ScheduledTask -TaskName "Configuration Manager Client Retry Task" -InputObject $Task -TaskPath 'Microsoft\Microsoft\Configuration Manager'
+Register-ScheduledTask -TaskName "Configuration Manager Client Retry Task" -InputObject $Task -TaskPath 'Microsoft\Configuration Manager'


### PR DESCRIPTION
Per this doc, the correct path for the scheduled task shouldn't have the extra Microsoft in it.

https://learn.microsoft.com/en-us/troubleshoot/mem/configmgr/client-installation/configmgr-clients-reinstall-every-five-hours